### PR TITLE
Rmdir local folders to avoid `rb_file_s_rename` errors on upgrade

### DIFF
--- a/Casks/youtube-music.rb
+++ b/Casks/youtube-music.rb
@@ -25,6 +25,8 @@ cask "youtube-music" do
 
   app "YouTube Music.app"
 
+  uninstall rmdir: "#{HOMEBREW_PREFIX}/Caskroom/youtube-music"
+
   postflight do
     print("Removing quarantine attribute from YouTube Music.app.\n")
     system "xattr -cr '/Applications/YouTube Music.app'"

--- a/readme.md
+++ b/readme.md
@@ -20,3 +20,7 @@ Additionally, use `--no-quarantine` with `brew install` on `arm64` machines, whi
 To upgrade manually, run `brew upgrade --cask youtube-music`.
 
 To uninstall, run `brew uninstall --cask youtube-music`. Additionally you can use `--zap` to remove app-data and if you want to remove the tap after uninstall, run `brew untap th-ch/youtube-music`.
+
+## Development
+
+The local tap is in `$(brew --prefix)/Library/Taps/th-ch/homebrew-youtube-music` (you can also run `brew edit youtube-music`).


### PR DESCRIPTION
This PR removes local folders to avoid errors on upgrade.