### PR TITLE
Use `:latest` version

### DIFF
--- a/Casks/youtube-music.rb
+++ b/Casks/youtube-music.rb
@@ -20,6 +20,11 @@ cask "youtube-music" do
 
   url "#{base_url}#{file_extension}"
 
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
   # TODO checksum
   sha256 :no_check
 

--- a/Casks/youtube-music.rb
+++ b/Casks/youtube-music.rb
@@ -13,7 +13,7 @@ cask "youtube-music" do
   odie "Cannot find the latest version" if (latest_url.nil?)
   latest_release = latest_url.delete_prefix("#{release_url}/tag/")
 
-  version latest_release
+  version :latest
 
   base_url = "#{release_url}/download/#{latest_release}/YouTube-Music-#{latest_release.delete_prefix('v')}"
   file_extension = Hardware::CPU.arm? ? "-arm64.dmg" : ".dmg"
@@ -24,8 +24,6 @@ cask "youtube-music" do
   sha256 :no_check
 
   app "YouTube Music.app"
-
-  uninstall rmdir: "#{HOMEBREW_PREFIX}/Caskroom/youtube-music"
 
   postflight do
     print("Removing quarantine attribute from YouTube Music.app.\n")


### PR DESCRIPTION
This PR switches the version to `:latest` to fix upgrades (now only based on the downloaded artifact), hopefully fixing https://github.com/th-ch/youtube-music/issues/2305 (problem is described in https://github.com/th-ch/youtube-music/issues/2305#issuecomment-2414019341)

```sh
$ brew upgrade --cask youtube-music
==> Upgrading 1 outdated package:
th-ch/youtube-music/youtube-music latest -> latest
==> Upgrading youtube-music
==> Backing App 'YouTube Music.app' up to '/opt/homebrew/Caskroom/youtube-music/latest/YouTube Music.app'
==> Removing App '/Applications/YouTube Music.app'
==> Moving App 'YouTube Music.app' to '/Applications/YouTube Music.app'
Removing quarantine attribute from YouTube Music.app.
==> Purging files for version latest of Cask youtube-music
🍺  youtube-music was successfully upgraded!

$ brew upgrade --cask youtube-music
Warning: Not upgrading youtube-music, the downloaded artifact has not changed
```